### PR TITLE
Fix transform fillna for categorical columns

### DIFF
--- a/metadata/core.py
+++ b/metadata/core.py
@@ -684,8 +684,12 @@ class Metadata:
             if coerce_types:
                 df2[col] = self._coerce(df2[col], block["type"]["logical_type"])
             if fillna is not None:
-                value = fillna[col] if isinstance(fillna, dict) else fillna
-                df2[col] = df2[col].fillna(value)
+                value = fillna.get(col) if isinstance(fillna, dict) else fillna
+                if value is not None:
+                    if isinstance(df2[col].dtype, CategoricalDtype):
+                        if value not in df2[col].cat.categories:
+                            df2[col] = df2[col].cat.add_categories([value])
+                    df2[col] = df2[col].fillna(value)
         if drop_extra:
             extra = set(df2.columns) - set(self._meta.keys())
             df2 = df2.drop(columns=list(extra))

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import numpy as np
+from pandas.testing import assert_series_equal
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from metadata import Metadata
+
+
+def test_transform_fillna_dict_missing_key():
+    m = Metadata()
+    m._meta = {
+        "x": {"type": {"logical_type": "integer"}},
+        "y": {"type": {"logical_type": "float"}},
+    }
+    df = pd.DataFrame({"x": [1, None], "y": [2.0, None]})
+    result = m.transform(df, fillna={"x": 0})
+    assert_series_equal(result["x"], pd.Series([1, 0], name="x", dtype="Int64"))
+    assert_series_equal(result["y"], pd.Series([2.0, np.nan], name="y"))
+
+
+def test_transform_fillna_adds_category():
+    m = Metadata()
+    m._meta = {
+        "cat": {"type": {"logical_type": "categorical"}},
+    }
+    df = pd.DataFrame({"cat": pd.Series(["a", None], dtype="category")})
+    result = m.transform(df, fillna={"cat": "b"})
+    assert list(result["cat"].cat.categories) == ["a", "b"]
+    expected = pd.Series(pd.Categorical(["a", "b"], categories=["a", "b"]), name="cat")
+    assert_series_equal(result["cat"], expected)
+


### PR DESCRIPTION
## Summary
- avoid KeyError in `Metadata.transform` when fillna dict has missing column
- ensure no filling occurs if no value provided
- handle categorical columns by adding fillna value to categories before filling
- add regression tests for missing dict key case and new categorical behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889b959dd3c832cac371f25e913be05