### PR TITLE
Add df upgrade feature and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,25 @@ m.update(df, 'https://ejemplo.com/esquemas.zip', verbose=True)
 ```
 Esto descargará el ZIP a un directorio temporal, aplicará las actualizaciones y dejará el archivo resultante en la misma carpeta (o en la ruta indicada con `output`).
 
+### Edición de metadatos vía `metadata.df`
+
+Tras `m.update()` el esquema queda en `m.df`, un DataFrame editable. Los cambios
+pueden propagarse al YAML con `m.df.upgrade()`:
+
+```python
+# 1) Si todas las columnas son enteros
+m.df['type.logical_type'] = 'integer'
+
+# 2) Cambiar la descripción de `age`
+m.df.loc['age', 'identity.description_i18n.es'] = 'Edad del pasajero'
+
+# 3) Ajustar el rango permitido de `age`
+m.df.loc['age', ['domain.numeric.min', 'domain.numeric.max']] = [0, 120]
+
+m.df.upgrade('schema.yaml')  # guarda el YAML actualizado
+m.df.revert()                # descarta cambios locales
+```
+
 ## Roadmap
 
 - ✔️ Soporte de YAML remoto (v 2025‑07‑30)

--- a/metadata/core.py
+++ b/metadata/core.py
@@ -259,6 +259,26 @@ def _to_frame(meta_dict: Dict[str, Dict[str, Any]], *, flat: bool = True, sep: s
     return pd.DataFrame(recs).set_index("__column__")
 
 
+def _unflatten(d: Dict[str, Any], *, sep: str = ".") -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k, v in d.items():
+        if k == "__column__" or (isinstance(v, float) and pd.isna(v)):
+            continue
+        current = out
+        parts = k.split(sep)
+        for part in parts[:-1]:
+            current = current.setdefault(part, {})
+        current[parts[-1]] = v
+    return out
+
+
+def _from_frame(df: pd.DataFrame, *, sep: str = ".") -> Dict[str, Dict[str, Any]]:
+    meta: Dict[str, Dict[str, Any]] = {}
+    for col, row in df.iterrows():
+        meta[col] = _unflatten(row.to_dict(), sep=sep)
+    return meta
+
+
 class Metadata:
     """Objeto principal para gestionar y validar metadatos."""
 
@@ -266,6 +286,24 @@ class Metadata:
         self._meta: Dict[str, Dict[str, Any]] = {}
         self._df_cache: Optional[pd.DataFrame] = None
         self._history: Dict[str, Dict[str, Any]] = {}
+
+    def _attach_upgrade(self) -> None:
+        if self._df_cache is None:
+            return
+
+        def upgrade(output: Optional[Union[str, pathlib.Path]] = None) -> None:
+            self._meta = _from_frame(self._df_cache)
+            if output:
+                path = pathlib.Path(output)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                data = {"schema": list(self._meta.values())}
+                path.write_text(yaml.safe_dump(data, sort_keys=False, allow_unicode=True), encoding="utf-8")
+        def revert() -> None:
+            self._df_cache = _to_frame(self._meta)
+            self._attach_upgrade()
+
+        setattr(self._df_cache, "upgrade", upgrade)
+        setattr(self._df_cache, "revert", revert)
 
     # ------------------------------------------------------------------
     #                           UPDATE
@@ -393,6 +431,7 @@ class Metadata:
         # -------- snapshot interno + df cache --------
         self._meta = aggregated
         self._df_cache = _to_frame(aggregated)
+        self._attach_upgrade()
         setattr(self, "_df_cache", self._df_cache)
 
     # ------------------------------------------------------------------
@@ -404,10 +443,15 @@ class Metadata:
 
     @property
     def df(self) -> Optional[pd.DataFrame]:
+        if self._df_cache is not None and not hasattr(self._df_cache, "upgrade"):
+            self._attach_upgrade()
         return self._df_cache
 
     def to_frame(self, *, flat: bool = True, sep: str = ".") -> pd.DataFrame:
-        return _to_frame(self._meta, flat=flat, sep=sep)
+        df = _to_frame(self._meta, flat=flat, sep=sep)
+        self._df_cache = df
+        self._attach_upgrade()
+        return df
 
     def printSchema(self) -> None:
         self._ensure_loaded()

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import yaml
+from pathlib import Path
+
+from metadata import Metadata
+
+
+def test_df_upgrade_updates_meta(tmp_path):
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    schema = {
+        'schema': [
+            {'identity': {'name': 'a'}, 'type': {'logical_type': 'integer'}},
+            {'identity': {'name': 'b'}, 'type': {'logical_type': 'integer'}},
+        ]
+    }
+    yaml_path = tmp_path / 'schema.yaml'
+    yaml_path.write_text(yaml.safe_dump(schema, sort_keys=False, allow_unicode=True))
+
+    m = Metadata()
+    m.update(df, yaml_path, inplace=True, verbose=False)
+    m.df.loc['a', 'type.logical_type'] = 'float'
+    m.df.upgrade()
+
+    assert m._meta['a']['type']['logical_type'] == 'float'
+
+
+def test_df_revert_restores_df(tmp_path):
+    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4]})
+    schema = {
+        'schema': [
+            {'identity': {'name': 'a'}, 'type': {'logical_type': 'integer'}},
+            {'identity': {'name': 'b'}, 'type': {'logical_type': 'integer'}},
+        ]
+    }
+    yaml_path = tmp_path / 'schema.yaml'
+    yaml_path.write_text(yaml.safe_dump(schema, sort_keys=False, allow_unicode=True))
+
+    m = Metadata()
+    m.update(df, yaml_path, inplace=True, verbose=False)
+    original = m.df.copy()
+    m.df.loc['a', 'type.logical_type'] = 'float'
+    m.df.revert()
+
+    assert m.df.equals(original)
+    assert m._meta['a']['type']['logical_type'] == 'integer'


### PR DESCRIPTION
## Summary
- add `_unflatten` & `_from_frame` helpers
- implement `df.upgrade()` to sync edits back to YAML
- update README with examples on editing metadata via `metadata.df`
- test `df.upgrade` functionality
- implement `df.revert()` to restore dataframe state
- test `df.revert` functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a413996b8832c9a6bc784affaf9d1